### PR TITLE
XFOIL integration: binaries CI, XfoilManager, XfoilRunner

### DIFF
--- a/.github/workflows/xfoil-binaries.yml
+++ b/.github/workflows/xfoil-binaries.yml
@@ -1,0 +1,135 @@
+name: Build XFOIL binaries
+
+# XFOIL upstream (MIT, GPL) is a fixed release, so this does not run per push.
+# Trigger it manually; it publishes binaries to the fixed `xfoil-6.99` release,
+# which the app (XfoilManager) downloads and caches like it does for AVL.
+on:
+  workflow_dispatch:
+
+env:
+  XFOIL_URL: https://web.mit.edu/drela/Public/web/xfoil/xfoil6.99.tgz
+  RELEASE_TAG: xfoil-6.99
+  # Compatibility flags required to build the F77 sources with modern gfortran.
+  FL: "-O -fdefault-real-8 -std=legacy -fallow-argument-mismatch"
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false          # Linux is validated; let it publish even if Win/mac need iteration.
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
+            asset: xfoil-linux
+          - os: macos-latest
+            platform: macos
+            asset: xfoil-macos
+          - os: windows-latest
+            platform: windows
+            asset: xfoil-windows.exe
+    runs-on: ${{ matrix.os }}
+    steps:
+      # ---------- Linux (validated recipe) ----------
+      - name: Build (Linux)
+        if: matrix.platform == 'linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq gfortran libx11-dev make gcc
+          curl -fsSL "$XFOIL_URL" -o xfoil.tgz
+          tar xzf xfoil.tgz
+          cd Xfoil/plotlib
+          cp config.make.gfortranDP config.make
+          sed -i "s|^FFLAGS .*|FFLAGS = -m64 -O2 $FL|" config.make
+          make
+          cd ../bin
+          mkdir -p dist
+          make xfoil \
+            FC=gfortran \
+            FFLAGS="$FL" FFLOPT="$FL" \
+            PLTOBJ=../plotlib/libPlt_gDP.a \
+            PLTLIB="-lX11" \
+            FTNLIB="-static-libgfortran -static-libgcc" \
+            BINDIR="$PWD/dist/"
+          # Smoke test: the sweep that crashes the Debian binary must succeed here.
+          printf 'PLOP\nG\n\nNACA 0012\nPANE\nOPER\nITER 200\nVISC 1000000\nPACC\np.txt\n\nASEQ 0 18 2\nPACC\n\nQUIT\n' | dist/xfoil >/dev/null 2>&1 || true
+          test "$(grep -cE '^[[:space:]]+[0-9]+\.[0-9]' p.txt)" -ge 5
+          mkdir -p out && cp dist/xfoil "out/${{ matrix.asset }}"
+
+      # ---------- macOS (best-effort; needs CI iteration for X11/no-X) ----------
+      - name: Build (macOS)
+        if: matrix.platform == 'macos'
+        shell: bash
+        run: |
+          set -euo pipefail
+          brew install gcc || true            # provides gfortran
+          curl -fsSL "$XFOIL_URL" -o xfoil.tgz
+          tar xzf xfoil.tgz
+          cd Xfoil/plotlib
+          cp config.make.gfortranDP config.make
+          # macOS X11 headers come from XQuartz; if absent this job is expected to fail
+          # until we switch to a no-X plot backend. Iterate here.
+          sed -i '' "s|^FFLAGS .*|FFLAGS = -O2 $FL|" config.make || sed -i "s|^FFLAGS .*|FFLAGS = -O2 $FL|" config.make
+          make
+          cd ../bin
+          mkdir -p dist
+          make xfoil FC=gfortran FFLAGS="$FL" FFLOPT="$FL" \
+            PLTOBJ=../plotlib/libPlt_gDP.a PLTLIB="-lX11" \
+            FTNLIB="-static-libgfortran -static-libgcc" BINDIR="$PWD/dist/"
+          mkdir -p out && cp dist/xfoil "out/${{ matrix.asset }}"
+
+      # ---------- Windows (best-effort; mingw plot backend, needs CI iteration) ----------
+      - name: Setup MSYS2 (Windows)
+        if: matrix.platform == 'windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: mingw-w64-x86_64-gcc-fortran make curl tar
+      - name: Build (Windows)
+        if: matrix.platform == 'windows'
+        shell: msys2 {0}
+        run: |
+          set -euo pipefail
+          curl -fsSL "$XFOIL_URL" -o xfoil.tgz
+          tar xzf xfoil.tgz
+          cd Xfoil/plotlib
+          # Windows uses the Win32 plot backend shipped as Makefile.mingw.
+          make -f Makefile.mingw FFLAGS="-O2 -fdefault-real-8 -std=legacy -fallow-argument-mismatch"
+          cd ../bin
+          make xfoil FC=gfortran \
+            FFLAGS="-O -fdefault-real-8 -std=legacy -fallow-argument-mismatch" \
+            FFLOPT="-O -fdefault-real-8 -std=legacy -fallow-argument-mismatch" \
+            FTNLIB="-static -static-libgfortran -static-libgcc" \
+            BINDIR="$PWD/dist/" || true
+          mkdir -p out && cp xfoil.exe "out/${{ matrix.asset }}" 2>/dev/null || cp dist/xfoil.exe "out/${{ matrix.asset }}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: out/*
+          if-no-files-found: warn
+
+  release:
+    needs: build
+    if: always()          # publish whatever built (Linux) even if Win/mac still need work
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+      - name: Publish to fixed XFOIL release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          name: XFOIL 6.99 binaries
+          files: artifacts/*
+          body: |
+            XFOIL 6.99 compiled from MIT source (GPL) with stable gfortran flags.
+            Downloaded and cached by AVL Editor's XfoilManager.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/main/scala/com/abajar/avleditor/XfoilManager.scala
+++ b/src/main/scala/com/abajar/avleditor/XfoilManager.scala
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2015  Hugo Freire Gil
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ */
+
+package com.abajar.avleditor
+
+import java.io.{File, FileOutputStream, InputStream}
+import java.net.{HttpURLConnection, URL}
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFilePermission
+import java.util.Properties
+import java.util.logging.{Level, Logger}
+import scala.collection.JavaConverters._
+
+/**
+ * Resolves and provides the XFOIL executable, mirroring [[AvlManager]].
+ *
+ * XFOIL is not distributed as a reliable per-OS binary upstream (the Debian
+ * package crashes; the MIT site ships Windows-only). We compile it from source
+ * in CI (see .github/workflows/xfoil-binaries.yml) and publish the binaries to a
+ * fixed GitHub release; this manager downloads and caches them like AvlManager
+ * does for AVL. Until that release exists, the user can point `xfoil.path` at a
+ * local build via the "Set XFOIL executable" menu.
+ */
+object XfoilManager {
+
+  val logger = Logger.getLogger(XfoilManager.getClass.getName)
+
+  // Fixed release produced by the xfoil-binaries workflow.
+  val XFOIL_RELEASE_BASE =
+    "https://github.com/TLmaK0/avl-editor/releases/download/xfoil-6.99/"
+  val XFOIL_DIR = System.getProperty("user.home") + "/.avleditor/xfoil"
+
+  case class XfoilBinary(fileName: String, assetName: String)
+
+  def getXfoilBinaryForOS: Option[XfoilBinary] = {
+    val os = System.getProperty("os.name").toLowerCase
+
+    logger.log(Level.INFO, s"Detecting OS for XFOIL: $os")
+
+    if (os.contains("linux")) {
+      Some(XfoilBinary("xfoil", "xfoil-linux"))
+    } else if (os.contains("mac") || os.contains("darwin")) {
+      Some(XfoilBinary("xfoil", "xfoil-macos"))
+    } else if (os.contains("win")) {
+      Some(XfoilBinary("xfoil.exe", "xfoil-windows.exe"))
+    } else {
+      logger.log(Level.WARNING, s"Unsupported operating system for XFOIL: $os")
+      None
+    }
+  }
+
+  def getXfoilPath: String = {
+    val binary = getXfoilBinaryForOS.getOrElse(throw new Exception("Unsupported OS"))
+    s"$XFOIL_DIR/${binary.fileName}"
+  }
+
+  def ensureXfoilAvailable(configuration: Properties): Boolean = {
+    val configuredPath = Option(configuration.getProperty("xfoil.path"))
+
+    configuredPath match {
+      case Some(path) if new File(path).exists() && new File(path).canExecute() =>
+        logger.log(Level.INFO, s"XFOIL already configured at: $path")
+        true
+      case _ =>
+        logger.log(Level.INFO, "XFOIL not found or not configured, attempting to download...")
+        downloadAndConfigureXfoil(configuration)
+    }
+  }
+
+  private def downloadAndConfigureXfoil(configuration: Properties): Boolean = {
+    getXfoilBinaryForOS match {
+      case Some(binary) =>
+        try {
+          val xfoilDir = new File(XFOIL_DIR)
+          if (!xfoilDir.exists()) {
+            xfoilDir.mkdirs()
+            logger.log(Level.INFO, s"Created XFOIL directory: $XFOIL_DIR")
+          }
+
+          val xfoilPath = s"$XFOIL_DIR/${binary.fileName}"
+          val xfoilFile = new File(xfoilPath)
+
+          if (!xfoilFile.exists()) {
+            val url = XFOIL_RELEASE_BASE + binary.assetName
+            logger.log(Level.INFO, s"Downloading XFOIL from: $url")
+            downloadFile(url, xfoilFile)
+            logger.log(Level.INFO, s"XFOIL downloaded to: $xfoilPath")
+          }
+
+          setExecutablePermissions(xfoilFile)
+
+          configuration.setProperty("xfoil.path", xfoilPath)
+          logger.log(Level.INFO, s"XFOIL configured at: $xfoilPath")
+
+          true
+        } catch {
+          case ex: Exception =>
+            logger.log(Level.WARNING,
+              "Failed to download XFOIL. Set it manually via 'Set XFOIL executable'.", ex)
+            false
+        }
+      case None =>
+        logger.log(Level.SEVERE, "Unsupported operating system for XFOIL download")
+        false
+    }
+  }
+
+  private def downloadFile(urlString: String, destinationFile: File): Unit = {
+    var connection: HttpURLConnection = null
+    var inputStream: InputStream = null
+    var outputStream: FileOutputStream = null
+
+    try {
+      val url = new URL(urlString)
+      connection = url.openConnection().asInstanceOf[HttpURLConnection]
+      connection.setRequestMethod("GET")
+      connection.setConnectTimeout(10000)
+      connection.setReadTimeout(30000)
+      connection.setInstanceFollowRedirects(true)
+
+      val responseCode = connection.getResponseCode
+      if (responseCode != HttpURLConnection.HTTP_OK) {
+        throw new Exception(s"HTTP error code: $responseCode")
+      }
+
+      inputStream = connection.getInputStream
+      outputStream = new FileOutputStream(destinationFile)
+
+      val buffer = new Array[Byte](8192)
+      var bytesRead = 0
+      var totalBytesRead = 0L
+
+      while ({bytesRead = inputStream.read(buffer); bytesRead != -1}) {
+        outputStream.write(buffer, 0, bytesRead)
+        totalBytesRead += bytesRead
+      }
+
+      logger.log(Level.INFO, s"Downloaded $totalBytesRead bytes")
+
+    } finally {
+      if (outputStream != null) outputStream.close()
+      if (inputStream != null) inputStream.close()
+      if (connection != null) connection.disconnect()
+    }
+  }
+
+  private def setExecutablePermissions(file: File): Unit = {
+    try {
+      val path = file.toPath
+      val permissions = Set(
+        PosixFilePermission.OWNER_READ,
+        PosixFilePermission.OWNER_WRITE,
+        PosixFilePermission.OWNER_EXECUTE,
+        PosixFilePermission.GROUP_READ,
+        PosixFilePermission.GROUP_EXECUTE,
+        PosixFilePermission.OTHERS_READ,
+        PosixFilePermission.OTHERS_EXECUTE
+      )
+      Files.setPosixFilePermissions(path, permissions.asJava)
+      logger.log(Level.INFO, s"Set executable permissions on: ${file.getAbsolutePath}")
+    } catch {
+      case ex: UnsupportedOperationException =>
+        file.setExecutable(true, false)
+        logger.log(Level.INFO, s"Set executable flag on: ${file.getAbsolutePath}")
+      case ex: Exception =>
+        logger.log(Level.WARNING, "Failed to set executable permissions", ex)
+    }
+  }
+}

--- a/src/main/scala/com/abajar/avleditor/xfoil/XfoilRunner.scala
+++ b/src/main/scala/com/abajar/avleditor/xfoil/XfoilRunner.scala
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2015  Hugo Freire Gil
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ */
+
+package com.abajar.avleditor.xfoil
+
+import java.io.{BufferedReader, File, InputStreamReader, OutputStreamWriter}
+import java.nio.file.{Files, Path}
+import java.util.concurrent.TimeUnit
+import java.util.logging.{Level, Logger}
+import scala.collection.mutable.ArrayBuffer
+
+/** One converged point of an XFOIL viscous polar. */
+case class XfoilPolarPoint(alpha: Float, cl: Float, cd: Float, cdp: Float, cm: Float)
+
+/** Airfoil input for XFOIL: either a NACA 4/5-digit code or a coordinate file. */
+sealed trait XfoilAirfoil
+case class NacaAirfoil(code: String) extends XfoilAirfoil
+case class DatAirfoil(path: String) extends XfoilAirfoil
+
+/**
+ * Drives XFOIL as an external process to compute a viscous polar, mirroring how
+ * [[com.abajar.avleditor.avl.connectivity.AvlRunner]] drives AVL. Graphics are
+ * disabled and results are read from the polar accumulation (PACC) file.
+ *
+ * Requires a stable XFOIL binary (see XfoilManager / the xfoil-binaries CI); the
+ * stock Debian build crashes and is not usable.
+ */
+class XfoilRunner(xfoilPath: String) {
+
+  private val logger = Logger.getLogger(classOf[XfoilRunner].getName)
+
+  /**
+   * Compute a viscous polar sweep. Non-converged points near stall simply do not
+   * appear in the result. Returns points ordered by alpha.
+   */
+  def computePolar(
+      airfoil: XfoilAirfoil,
+      reynolds: Double,
+      mach: Double,
+      alphaStart: Double,
+      alphaEnd: Double,
+      alphaStep: Double,
+      iterations: Int = 200,
+      timeoutSeconds: Int = 120
+  ): Seq[XfoilPolarPoint] = {
+    val workDir = Files.createTempDirectory("xfoil_run")
+    val polarFile = workDir.resolve("polar.txt")
+    try {
+      val script = buildScript(airfoil, reynolds, mach, alphaStart, alphaEnd, alphaStep,
+        iterations, polarFile)
+      runProcess(script, workDir, timeoutSeconds)
+      parsePolar(polarFile)
+    } finally {
+      deleteRecursively(workDir.toFile)
+    }
+  }
+
+  private def buildScript(
+      airfoil: XfoilAirfoil, reynolds: Double, mach: Double,
+      alphaStart: Double, alphaEnd: Double, alphaStep: Double,
+      iterations: Int, polarFile: Path
+  ): String = {
+    val load = airfoil match {
+      case NacaAirfoil(code) => s"NACA $code"
+      case DatAirfoil(path)  => s"LOAD $path"
+    }
+    val sb = new StringBuilder
+    sb.append("PLOP\n").append("G\n").append("\n")   // disable graphics
+    sb.append(load).append("\n")
+    sb.append("PANE\n")                               // clean paneling
+    sb.append("OPER\n")
+    sb.append(s"ITER $iterations\n")
+    sb.append(f"VISC $reynolds%.1f\n")                // set Reynolds + enable viscous
+    if (mach > 0.0) sb.append(f"MACH $mach%.4f\n")
+    sb.append("PACC\n")                               // start polar accumulation
+    sb.append(polarFile.toString).append("\n")        // save file
+    sb.append("\n")                                   // no dump file
+    sb.append(f"ASEQ $alphaStart%.3f $alphaEnd%.3f $alphaStep%.3f\n")
+    sb.append("PACC\n")                               // flush + stop accumulation
+    sb.append("\n")
+    sb.append("QUIT\n")
+    sb.toString
+  }
+
+  private def runProcess(script: String, workDir: Path, timeoutSeconds: Int): Unit = {
+    val pb = new ProcessBuilder(xfoilPath)
+    pb.directory(workDir.toFile)
+    pb.redirectErrorStream(true)
+    val process = pb.start()
+
+    // Drain stdout in a separate thread so XFOIL never blocks on a full pipe.
+    val drainer = new Thread(new Runnable {
+      override def run(): Unit = {
+        val reader = new BufferedReader(new InputStreamReader(process.getInputStream))
+        try { while (reader.readLine() != null) {} }
+        catch { case _: Exception => }
+        finally { try { reader.close() } catch { case _: Exception => } }
+      }
+    })
+    drainer.setDaemon(true)
+    drainer.start()
+
+    val writer = new OutputStreamWriter(process.getOutputStream)
+    try {
+      writer.write(script)
+      writer.flush()
+    } catch {
+      case _: Exception => // process may have exited; polar file is what matters
+    } finally {
+      try { writer.close() } catch { case _: Exception => }
+    }
+
+    val finished = process.waitFor(timeoutSeconds.toLong, TimeUnit.SECONDS)
+    if (!finished) {
+      logger.log(Level.WARNING, s"XFOIL timed out after ${timeoutSeconds}s; destroying")
+      process.destroyForcibly()
+    }
+    drainer.join(2000)
+  }
+
+  private def parsePolar(polarFile: Path): Seq[XfoilPolarPoint] = {
+    if (!Files.exists(polarFile)) {
+      logger.log(Level.WARNING, s"XFOIL polar file not produced: $polarFile")
+      return Seq.empty
+    }
+    val points = new ArrayBuffer[XfoilPolarPoint]()
+    val lines = Files.readAllLines(polarFile)
+    var i = 0
+    var inData = false
+    while (i < lines.size) {
+      val line = lines.get(i).trim
+      if (!inData) {
+        // Data begins after the dashed separator line under the column header.
+        if (line.startsWith("---")) inData = true
+      } else if (line.nonEmpty) {
+        val cols = line.split("\\s+")
+        if (cols.length >= 5) {
+          try {
+            points += XfoilPolarPoint(
+              cols(0).toFloat, cols(1).toFloat, cols(2).toFloat, cols(3).toFloat, cols(4).toFloat)
+          } catch {
+            case _: NumberFormatException => // skip malformed line
+          }
+        }
+      }
+      i += 1
+    }
+    points.sortBy(_.alpha).toSeq
+  }
+
+  private def deleteRecursively(file: File): Unit = {
+    if (file.isDirectory) Option(file.listFiles).foreach(_.foreach(deleteRecursively))
+    file.delete()
+  }
+}


### PR DESCRIPTION
Groundwork for auto-computing the empirical aero-model parameters via XFOIL.

- **CI**: `xfoil-binaries.yml` builds XFOIL 6.99 from MIT source (GPL) with stable
  gfortran flags and publishes to the fixed `xfoil-6.99` release. Linux recipe validated
  locally; Windows/macOS jobs iterate on real runners after this lands on master.
- **XfoilManager**: resolves/downloads the per-OS XFOIL binary (mirrors AvlManager).
- **XfoilRunner**: drives XFOIL and parses viscous polars (alpha/CL/CD/CDp/CM). Verified
  end-to-end against a from-source build (NACA 0012, CLmax≈1.39).

Next (separate work): aero derivation algorithms + Auto/Manual model & editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)