### PR TITLE
Phase 3: derive attached-flow aero params from XFOIL polars

### DIFF
--- a/src/main/scala/com/abajar/avleditor/xfoil/AeroDerivation.scala
+++ b/src/main/scala/com/abajar/avleditor/xfoil/AeroDerivation.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2015  Hugo Freire Gil
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ */
+
+package com.abajar.avleditor.xfoil
+
+/**
+ * Values derived from XFOIL polars for the empirical aero-model parameters that
+ * AVL cannot compute. Only the physically well-grounded, attached-flow quantities
+ * are produced here; each is an `Option`, so a value that cannot be derived
+ * confidently is left to its existing default rather than fabricated.
+ *
+ * Deliberately NOT derived here (see notes):
+ *  - CD_prof: comes from AVL (viscous drag), not XFOIL.
+ *  - CL_drop / CD_stall / eta_loc: CRRCsim-stall-model-specific empirical params
+ *    with no first-principles mapping from a polar; left to the user/defaults.
+ */
+case class DerivedAero(
+  clMax: Option[Float] = None,
+  clMin: Option[Float] = None,
+  clCD0: Option[Float] = None,
+  cdCLsq: Option[Float] = None,
+  uexpCD: Option[Float] = None
+)
+
+object AeroDerivation {
+
+  /**
+   * Empirical finite-wing correction: 3D CL_max is lower than the 2D section
+   * cl_max. 0.9 is a common first-order factor; the accurate value comes from a
+   * critical-section analysis using AVL's spanwise loading (future refinement).
+   */
+  val CLMAX_3D_FACTOR: Float = 0.9f
+
+  /**
+   * @param polar        viscous polar at the operating Reynolds (ordered by alpha)
+   * @param higherRe      optional (polar, ReLow, ReHigh) for the Reynolds drag-scaling exponent
+   */
+  def deriveFromPolar(
+      polar: Seq[XfoilPolarPoint],
+      higherRe: Option[(Seq[XfoilPolarPoint], Double, Double)] = None
+  ): DerivedAero = {
+    if (polar.isEmpty) return DerivedAero()
+
+    val cls = polar.map(_.cl)
+    val clMax2D = cls.max
+    val clMin2D = cls.min
+    val clAtMinCd = polar.minBy(_.cd).cl
+
+    DerivedAero(
+      clMax = Some(CLMAX_3D_FACTOR * clMax2D),
+      clMin = Some(CLMAX_3D_FACTOR * clMin2D),
+      clCD0 = Some(clAtMinCd),
+      cdCLsq = fitCdVsClSquared(polar),
+      uexpCD = higherRe.flatMap { case (p2, reLow, reHigh) => fitReynoldsExponent(polar, p2, reLow, reHigh) }
+    )
+  }
+
+  /**
+   * Slope of the parabolic profile polar: CD ≈ CD0 + k·CL², k = CD_CLsq.
+   * Least-squares fit of CD on CL² over the attached-flow region (CL ≤ 0.9·CLmax),
+   * which is where the polar is parabolic. Returns None if too few points.
+   */
+  private def fitCdVsClSquared(polar: Seq[XfoilPolarPoint]): Option[Float] = {
+    val clMax = polar.map(_.cl).max
+    val attached = polar.filter(p => p.cl <= 0.9f * clMax)
+    if (attached.length < 3) return None
+
+    val xs = attached.map(p => (p.cl * p.cl).toDouble)   // CL²
+    val ys = attached.map(_.cd.toDouble)                 // CD
+    val n = xs.length
+    val sx = xs.sum
+    val sy = ys.sum
+    val sxx = xs.map(x => x * x).sum
+    val sxy = xs.zip(ys).map { case (x, y) => x * y }.sum
+    val denom = n * sxx - sx * sx
+    if (math.abs(denom) < 1e-12) return None
+    val slope = (n * sxy - sx * sy) / denom
+    if (slope.isNaN || slope <= 0.0) None else Some(slope.toFloat)
+  }
+
+  /**
+   * Reynolds scaling exponent of profile drag: CD ∝ Re^n. In CRRCsim,
+   * CD_prof ~ (U/U_ref)^Uexp_CD and Re ∝ U for fixed geometry, so Uexp_CD ≈ n.
+   * Estimated from the minimum CD at two Reynolds numbers.
+   */
+  private def fitReynoldsExponent(
+      polarLow: Seq[XfoilPolarPoint], polarHigh: Seq[XfoilPolarPoint],
+      reLow: Double, reHigh: Double
+  ): Option[Float] = {
+    if (polarLow.isEmpty || polarHigh.isEmpty || reLow <= 0 || reHigh <= 0 || reLow == reHigh) return None
+    val cdLow = polarLow.map(_.cd).min.toDouble
+    val cdHigh = polarHigh.map(_.cd).min.toDouble
+    if (cdLow <= 0 || cdHigh <= 0) return None
+    val n = math.log(cdHigh / cdLow) / math.log(reHigh / reLow)
+    if (n.isNaN || n.isInfinite) None else Some(n.toFloat)
+  }
+}

--- a/src/test/scala/com/abajar/avleditor/xfoil/AeroDerivationCheck.scala
+++ b/src/test/scala/com/abajar/avleditor/xfoil/AeroDerivationCheck.scala
@@ -1,0 +1,49 @@
+/*
+ * Manual verification for AeroDerivation using a real NACA 0012 XFOIL polar
+ * (Re=1e6, alpha 0..16). Run with:  sbt "test:runMain com.abajar.avleditor.xfoil.AeroDerivationCheck"
+ */
+package com.abajar.avleditor.xfoil
+
+object AeroDerivationCheck {
+
+  private val naca0012Polar: Seq[XfoilPolarPoint] = Seq(
+    XfoilPolarPoint(0.0f,  0.0000f, 0.00540f, 0.00046f, -0.0000f),
+    XfoilPolarPoint(2.0f,  0.2142f, 0.00580f, 0.00064f,  0.0030f),
+    XfoilPolarPoint(4.0f,  0.4278f, 0.00728f, 0.00118f,  0.0060f),
+    XfoilPolarPoint(6.0f,  0.6948f, 0.00973f, 0.00224f, -0.0043f),
+    XfoilPolarPoint(8.0f,  0.9099f, 0.01211f, 0.00356f, -0.0039f),
+    XfoilPolarPoint(10.0f, 1.0809f, 0.01498f, 0.00533f,  0.0053f),
+    XfoilPolarPoint(12.0f, 1.2454f, 0.01936f, 0.00825f,  0.0133f),
+    XfoilPolarPoint(14.0f, 1.3501f, 0.02611f, 0.01279f,  0.0267f),
+    XfoilPolarPoint(16.0f, 1.3877f, 0.04171f, 0.02442f,  0.0302f)
+  )
+
+  def main(args: Array[String]): Unit = {
+    val d = AeroDerivation.deriveFromPolar(naca0012Polar)
+    println(s"derived: $d")
+
+    var ok = true
+    def check(name: String, cond: Boolean): Unit = {
+      println((if (cond) "  PASS " else "  FAIL ") + name); ok &= cond
+    }
+
+    // clMax3D = 0.9 * clMax2D(1.3877) = 1.2489
+    check("clMax ≈ 1.249", d.clMax.exists(v => math.abs(v - 1.2489f) < 0.01f))
+    // symmetric airfoil, alpha>=0 sweep -> clMin ~ 0
+    check("clMin ≈ 0", d.clMin.exists(v => math.abs(v) < 0.01f))
+    // min drag at alpha 0 -> CL at min CD ~ 0
+    check("clCD0 ≈ 0", d.clCD0.exists(v => math.abs(v) < 0.05f))
+    // parabolic-polar curvature: physically sane, order ~0.01
+    check("cdCLsq in (0.004, 0.02)", d.cdCLsq.exists(v => v > 0.004f && v < 0.02f))
+    check("uexpCD None (single Reynolds)", d.uexpCD.isEmpty)
+
+    // Reynolds-exponent path with a synthetic higher-Re polar (lower drag).
+    val highRe = naca0012Polar.map(p => p.copy(cd = p.cd * 0.85f))
+    val d2 = AeroDerivation.deriveFromPolar(naca0012Polar, Some((highRe, 1.0e6, 3.0e6)))
+    // cd2/cd1 = 0.85 over Re ratio 3 -> n = ln(0.85)/ln(3) ≈ -0.148
+    check("uexpCD ≈ -0.148", d2.uexpCD.exists(v => math.abs(v + 0.148f) < 0.01f))
+
+    println(if (ok) "AERO_DERIVATION_OK" else "AERO_DERIVATION_FAIL")
+    if (!ok) sys.exit(1)
+  }
+}


### PR DESCRIPTION
AeroDerivation computes CL_max/CL_min (3D-corrected), CL_CD0, CD_CLsq, Uexp_CD from XFOIL polars. Verified against a real NACA 0012 polar. Post-stall params left to defaults (see notes). 🤖 Generated with [Claude Code](https://claude.com/claude-code)