### PR TITLE
JSBSim export pipeline (writer + AVL/XFOIL + app wiring)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,10 @@
 # AVL Editor
 
-This project is an editor for CRRCsim, a radio-controlled aircraft simulator, and integrates with AVL for aerodynamic analysis.
-It allows users to modify aircraft parameters and configurations for simulation.
+This project is an editor for radio-controlled / small-UAV aircraft. It integrates with AVL
+for aerodynamic analysis and exports **JSBSim** flight dynamics models (metric), which run in
+JSBSim standalone, FlightGear and PX4 SITL (px4-jsbsim-bridge). It can also build XFOIL from
+source (CI) to derive viscous data. The legacy CRRCsim export has been removed.
+It allows users to modify aircraft geometry, mass and configuration for simulation.
 Developed in Java and Scala, it provides a GUI for streamlined editing and analysis.
 
 ## Building and Running

--- a/src/main/java/com/abajar/avleditor/crrcsim/CRRCSimRepository.java
+++ b/src/main/java/com/abajar/avleditor/crrcsim/CRRCSimRepository.java
@@ -62,6 +62,13 @@ public class CRRCSimRepository {
                 LoaderOptions loaderOptions = new LoaderOptions();
                 loaderOptions.setTagInspector(tag -> true);
                 Constructor constructor = new Constructor(CRRCSim.class, loaderOptions);
+                // Tolerate keys for fields that no longer exist (e.g. CRRCsim-era
+                // config.aero / aeroModel removed in the JSBSim migration).
+                org.yaml.snakeyaml.introspector.PropertyUtils pu =
+                    new org.yaml.snakeyaml.introspector.PropertyUtils();
+                pu.setSkipMissingProperties(true);
+                pu.setBeanAccess(BeanAccess.FIELD);
+                constructor.setPropertyUtils(pu);
                 Yaml yaml = new Yaml(constructor);
                 yaml.setBeanAccess(BeanAccess.FIELD);
                 FileInputStream fis = new FileInputStream(file);

--- a/src/main/scala/com/abajar/avleditor/AvlEditor.scala
+++ b/src/main/scala/com/abajar/avleditor/AvlEditor.scala
@@ -477,6 +477,7 @@ object AvlEditor{
       case SaveAs => saveFile
       case Open => openFile
       case ExportAsAvl => exportAsAVL
+      case ExportAsJsbsim => exportAsJsbsim
       case RunAvl => runAvl
       case SetAvlExecutable => setAvlExecutable
       case ClearAvlConfiguration => clearAvlConfiguration
@@ -754,6 +755,36 @@ object AvlEditor{
         this.configuration.setProperty("crrcsim.save",file.getAbsolutePath())
         exportAsAVL(Paths.get(file.getPath()))
       })
+    }
+
+    private def exportAsJsbsim: Unit = {
+      if (!existsAvlExecutable) {
+        logger.log(Level.WARNING, "AVL executable not configured; cannot compute derivatives for JSBSim export")
+        return
+      }
+      val avl = crrcsim.getAvl()
+      val errors = avl.getGeometry().validate()
+      if (!errors.isEmpty) {
+        import scala.collection.JavaConverters._
+        errors.asScala.foreach(e => logger.log(Level.WARNING, s"Validation error: $e"))
+        logger.log(Level.SEVERE, "Model validation failed; fix errors before exporting to JSBSim.")
+        return
+      }
+      val dirDialog = new org.eclipse.swt.widgets.DirectoryDialog(window.getShell)
+      dirDialog.setText("Choose JSBSim output directory")
+      Option(dirDialog.open()).foreach { dir =>
+        try {
+          crrcsim.calculate()
+          val avlPath = configuration.getProperty("avl.path")
+          val calc = new AvlRunner(avlPath, avl, crrcsim.getOriginPath()).getCalculation()
+          val name = currentFile.map(_.getName.replaceAll("\\.[^.]+$", "")).getOrElse("aircraft")
+          com.abajar.avleditor.jsbsim.JsbsimExporter.export(new File(dir), name, crrcsim, calc)
+          logger.log(Level.INFO, s"Exported JSBSim model '$name' to $dir")
+        } catch {
+          case ex: Throwable =>
+            logger.log(Level.SEVERE, s"JSBSim export failed: ${ex.getMessage}", ex)
+        }
+      }
     }
 
     def runAvl: Unit = {

--- a/src/main/scala/com/abajar/avleditor/jsbsim/JsbsimExporter.scala
+++ b/src/main/scala/com/abajar/avleditor/jsbsim/JsbsimExporter.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2015  Hugo Freire Gil
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ */
+
+package com.abajar.avleditor.jsbsim
+
+import com.abajar.avleditor.crrcsim.CRRCSim
+import com.abajar.avleditor.avl.runcase.AvlCalculation
+import com.abajar.avleditor.UnitConversor
+import java.io.{File, PrintWriter}
+import scala.collection.JavaConverters._
+import JsbsimWriter._
+
+/**
+ * Builds a [[JsbsimWriter.Aircraft]] from the editor model plus an AVL calculation and
+ * writes the JSBSim files (metric) to a root directory: the aircraft XML under
+ * `aircraft/<name>/` and any motor/propeller files under `engine/`.
+ *
+ * Assumptions (documented for later refinement):
+ *  - `MassInertia` is SI (kg, kg·m²); CG and AERORP share the geometry frame (converted
+ *    to metres). Control max deflections default per surface (AVL carries no limit).
+ *  - Propulsion is not mapped yet from the electric power model; a glider is exported.
+ *    JsbsimWriter already supports BLDC propulsion once that mapping is wired.
+ */
+object JsbsimExporter {
+
+  private val DefaultElevatorDeflRad = math.toRadians(25)
+  private val DefaultAileronDeflRad = math.toRadians(20)
+  private val DefaultRudderDeflRad = math.toRadians(25)
+
+  def buildAircraft(name: String, crrcsim: CRRCSim, calc: AvlCalculation): Aircraft = {
+    val avl = crrcsim.getAvl
+    val geo = avl.getGeometry
+    val lu = avl.getLengthUnit
+    val uc = new UnitConversor
+
+    val sref = uc.convertToSquareMeters(geo.getSref, lu).toDouble
+    val bref = uc.convertToMeters(geo.getBref, lu).toDouble
+    val cref = uc.convertToMeters(geo.getCref, lu).toDouble
+    val aeroRp = Vec3(
+      uc.convertToMeters(geo.getXref, lu), uc.convertToMeters(geo.getYref, lu), uc.convertToMeters(geo.getZref, lu))
+
+    val mi = crrcsim.getConfig.getMass_inertia
+    val com = crrcsim.getCenterOfMass
+    val cg = Vec3(com.getX.toDouble, com.getY.toDouble, com.getZ.toDouble)
+    val mass = MassBalance(mi.getMass.toDouble, mi.getI_xx.toDouble, mi.getI_yy.toDouble,
+      mi.getI_zz.toDouble, mi.getI_xz.toDouble, cg)
+
+    val aero = buildAero(calc, sref, bref)
+    val controls = detectControls(geo)
+    // A single belly contact keeps the model on the ground; real gear can replace it.
+    val contacts = Seq(Contact("BELLY", Vec3(cg.x, cg.y, cg.z - 0.1)))
+
+    Aircraft(name, Metrics(sref, bref, cref, aeroRp), mass, contacts, controls, aero)
+  }
+
+  private def buildAero(calc: AvlCalculation, sref: Double, bref: Double): AeroDerivatives = {
+    val std = calc.getStabilityDerivatives
+    val cfg = calc.getConfiguration
+    val ep = calc.getElevatorPosition
+    val rp = calc.getRudderPosition
+    val ap = calc.getAileronPosition
+    def at(a: Array[Float], i: Int): Double = if (a != null && i >= 0 && i < a.length) a(i).toDouble else 0.0
+    val ar = if (sref > 0) bref * bref / sref else 5.0
+    val e = Option(cfg.getE).map(_.doubleValue).filter(_ > 0).getOrElse(0.85)
+    new AeroDerivatives(
+      cl0 = cfg.getCLtot, cla = std.getCLa, clq = std.getCLq, clde = at(std.getCLd, ep),
+      cd0 = cfg.getCDvis, spanEfficiency = e, aspectRatio = ar, cdde = 0.0,
+      cm0 = cfg.getCmtot, cma = std.getCma, cmq = std.getCmq, cmde = at(std.getCmd, ep),
+      cyb = std.getCYb, cyp = std.getCYp, cyr = std.getCYr, cydr = at(std.getCYd, rp), cyda = at(std.getCYd, ap),
+      clb = std.getClb, clp = std.getClp, clr = std.getClr, cldr = at(std.getCld, rp), clda = at(std.getCld, ap),
+      cnb = std.getCnb, cnp = std.getCnp, cnr = std.getCnr, cndr = at(std.getCnd, rp), cnda = at(std.getCnd, ap)
+    )
+  }
+
+  /** Detect the aileron/elevator/rudder surfaces present, one FCS channel each. */
+  private def detectControls(geo: com.abajar.avleditor.avl.AVLGeometry): Seq[ControlSurface] = {
+    val names = geo.getSurfaces.asScala
+      .flatMap(_.getSections.asScala)
+      .flatMap(_.getControls.asScala)
+      .map(c => Option(c.getName).getOrElse("").toLowerCase)
+      .toSet
+    def has(keys: String*) = keys.exists(k => names.exists(_.contains(k)))
+    var out = List.empty[ControlSurface]
+    if (has("elev", "ele", "pitch")) out ::= ControlSurface(ControlAxis.Elevator, DefaultElevatorDeflRad)
+    if (has("ail", "flap", "roll")) out ::= ControlSurface(ControlAxis.Aileron, DefaultAileronDeflRad)
+    if (has("rud", "yaw")) out ::= ControlSurface(ControlAxis.Rudder, DefaultRudderDeflRad)
+    out
+  }
+
+  /** Write the aircraft + engine files under `rootDir` in JSBSim's expected layout. */
+  def export(rootDir: File, name: String, crrcsim: CRRCSim, calc: AvlCalculation): Unit = {
+    val model = generate(buildAircraft(name, crrcsim, calc))
+    writeFile(new File(rootDir, s"aircraft/$name/$name.xml"), model.aircraftXml)
+    model.engineFiles.foreach { case (fn, content) => writeFile(new File(rootDir, s"engine/$fn"), content) }
+  }
+
+  private def writeFile(f: File, content: String): Unit = {
+    Option(f.getParentFile).foreach(_.mkdirs())
+    val pw = new PrintWriter(f)
+    try pw.write(content) finally pw.close()
+  }
+}

--- a/src/main/scala/com/abajar/avleditor/jsbsim/JsbsimWriter.scala
+++ b/src/main/scala/com/abajar/avleditor/jsbsim/JsbsimWriter.scala
@@ -56,8 +56,16 @@ object JsbsimWriter {
   /** Optional XFOIL-derived non-linear lift curve (alpha rad -> CL), overrides cl0+cla. */
   final case class LiftTable(alphaRadToCl: Seq[(Double, Double)])
 
-  /** Optional electric propulsion (kept minimal; refined in the propulsion phase). */
-  final case class Propulsion(engineName: String, thrusterName: String)
+  /**
+   * Optional electric propulsion: a brushless DC motor (RC-style: Kv, coil resistance,
+   * no-load current, battery voltage) driving a fixed-pitch tractor propeller. The BLDC
+   * model self-limits RPM via back-EMF, which a bare power model does not.
+   */
+  final case class Propulsion(motorKv: Double, batteryVolts: Double, coilResistanceOhm: Double,
+                              noLoadCurrentA: Double, propDiameterM: Double, numBlades: Int, at: Vec3)
+
+  /** The generated aircraft plus the auxiliary engine/thruster files it references. */
+  final case class GeneratedModel(name: String, aircraftXml: String, engineFiles: Seq[(String, String)])
 
   final case class Aircraft(
     name: String,
@@ -76,7 +84,11 @@ object JsbsimWriter {
 
   // ---- Rendering ----
 
-  def write(ac: Aircraft): String = {
+  private def engineName(ac: Aircraft) = ac.name + "_motor"
+  private def propName(ac: Aircraft) = ac.name + "_prop"
+
+  /** Full export: the aircraft XML plus any engine/thruster files it references. */
+  def generate(ac: Aircraft): GeneratedModel = {
     val sb = new StringBuilder
     sb.append("""<?xml version="1.0"?>""").append("\n")
     sb.append(s"""<fdm_config name="${xml(ac.name)}" version="2.0" release="ALPHA">""").append("\n")
@@ -84,12 +96,23 @@ object JsbsimWriter {
     sb.append(metrics(ac.metrics))
     sb.append(massBalance(ac.mass))
     sb.append(groundReactions(ac.contacts))
-    sb.append(propulsion(ac.propulsion))
+    sb.append(propulsion(ac))
     sb.append(flightControl(ac.controls))
     sb.append(aerodynamics(ac))
     sb.append("</fdm_config>\n")
-    sb.toString
+
+    val engineFiles = ac.propulsion match {
+      case None => Seq.empty
+      case Some(pr) => Seq(
+        engineName(ac) + ".xml" -> brushlessMotorFile(engineName(ac), pr),
+        propName(ac) + ".xml" -> propellerFile(propName(ac), pr.propDiameterM, pr.numBlades)
+      )
+    }
+    GeneratedModel(ac.name, sb.toString, engineFiles)
   }
+
+  /** Convenience: the aircraft XML only (no auxiliary files). */
+  def write(ac: Aircraft): String = generate(ac).aircraftXml
 
   private def f(v: Double): String = {
     if (v == 0.0) "0" else new java.math.BigDecimal(v).round(new java.math.MathContext(8)).toPlainString
@@ -142,16 +165,79 @@ object JsbsimWriter {
     s"  <ground_reactions>\n$body  </ground_reactions>\n"
   }
 
-  private def propulsion(p: Option[Propulsion]): String = p match {
+  private def propulsion(ac: Aircraft): String = ac.propulsion match {
     case None => "  <propulsion/>\n"
     case Some(pr) =>
       s"""  <propulsion>
-      |    <engine file="${xml(pr.engineName)}">
-      |      <thruster file="${xml(pr.thrusterName)}"><location unit="M"><x>0</x><y>0</y><z>0</z></location></thruster>
+      |    <engine file="${engineName(ac)}">
+      |      <thruster file="${propName(ac)}">
+      |        <location unit="M"><x>${f(pr.at.x)}</x><y>${f(pr.at.y)}</y><z>${f(pr.at.z)}</z></location>
+      |        <orient unit="DEG"><roll>0</roll><pitch>0</pitch><yaw>0</yaw></orient>
+      |      </thruster>
       |    </engine>
       |  </propulsion>
       |""".stripMargin
   }
+
+  private def brushlessMotorFile(name: String, pr: Propulsion): String =
+    s"""<?xml version="1.0"?>
+    |<brushless_dc_motor name="${xml(name)}">
+    |  <velocityconstant>${f(pr.motorKv)}</velocityconstant>
+    |  <coilresistance>${f(pr.coilResistanceOhm)}</coilresistance>
+    |  <noloadcurrent>${f(pr.noLoadCurrentA)}</noloadcurrent>
+    |  <maxvolts>${f(pr.batteryVolts)}</maxvolts>
+    |</brushless_dc_motor>
+    |""".stripMargin
+
+  private def propellerFile(name: String, diameterM: Double, numBlades: Int): String = {
+    val ixx = 1.06e-3 * diameterM * diameterM // scaled from the DJI 9450 reference prop
+    s"""<?xml version="1.0"?>
+    |<propeller name="${xml(name)}" version="1.1">
+    |  <ixx unit="KG*M2">${f(ixx)}</ixx>
+    |  <diameter unit="M">${f(diameterM)}</diameter>
+    |  <numblades>$numBlades</numblades>
+    |  <constspeed>0</constspeed>
+    |  <table name="C_THRUST" type="internal">
+    |    <tableData>
+    |$GENERIC_CT
+    |    </tableData>
+    |  </table>
+    |  <table name="C_POWER" type="internal">
+    |    <tableData>
+    |$GENERIC_CP
+    |    </tableData>
+    |  </table>
+    |</propeller>
+    |""".stripMargin
+  }
+
+  // Generic small fixed-pitch propeller coefficients vs advance ratio J
+  // (from the APC 9x4.5e / JSBSim DJI_9450 reference; normalised by J so reusable).
+  private val GENERIC_CT =
+    """      0.0000 0.1288
+      |      0.0730 0.1230
+      |      0.1470 0.1153
+      |      0.2287 0.1053
+      |      0.3022 0.0932
+      |      0.3757 0.0794
+      |      0.4496 0.0644
+      |      0.5296 0.0483
+      |      0.6039 0.0310
+      |      0.6774 0.0128
+      |      0.7291 -0.0001""".stripMargin
+
+  private val GENERIC_CP =
+    """      0.0000 0.0666
+      |      0.0730 0.0611
+      |      0.1470 0.0567
+      |      0.2287 0.0531
+      |      0.3022 0.0498
+      |      0.3757 0.0456
+      |      0.4496 0.0402
+      |      0.5296 0.0332
+      |      0.6039 0.0243
+      |      0.6774 0.0137
+      |      0.7291 0.0061""".stripMargin
 
   private def flightControl(controls: Seq[ControlSurface]): String = {
     val channels = controls.map { c =>

--- a/src/main/scala/com/abajar/avleditor/jsbsim/JsbsimWriter.scala
+++ b/src/main/scala/com/abajar/avleditor/jsbsim/JsbsimWriter.scala
@@ -1,0 +1,281 @@
+/*
+ * Copyright (C) 2015  Hugo Freire Gil
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ */
+
+package com.abajar.avleditor.jsbsim
+
+/**
+ * Generates a JSBSim aircraft definition (`<fdm_config>`) in **metric** units.
+ *
+ * The aerodynamics are built from AVL stability derivatives (linear model). Where
+ * an XFOIL-derived lift table is supplied it overrides the linear CL(alpha) so the
+ * model captures CLmax/stall. Propulsion is optional (a glider is valid).
+ *
+ * The generated model targets JSBSim standalone, FlightGear and PX4 SITL
+ * (px4-jsbsim-bridge), which all consume the same format.
+ */
+object JsbsimWriter {
+
+  // ---- Input data (simulator-agnostic; built from the editor model elsewhere) ----
+
+  final case class Vec3(x: Double, y: Double, z: Double)
+
+  /** Reference geometry (metric). aeroRp = aerodynamic reference point. */
+  final case class Metrics(wingAreaM2: Double, wingSpanM: Double, chordM: Double, aeroRp: Vec3)
+
+  /** Mass & inertia (kg, kg·m²) and CG location (m). */
+  final case class MassBalance(massKg: Double, ixx: Double, iyy: Double, izz: Double,
+                               ixz: Double, cg: Vec3)
+
+  /** A landing-gear / collision contact point (m). */
+  final case class Contact(name: String, at: Vec3)
+
+  /** A control surface driven by a pilot command, with its max deflection (rad). */
+  final case class ControlSurface(axis: ControlAxis.Value, maxDeflectionRad: Double)
+
+  /**
+   * Linear aerodynamic model from AVL. Angles in rad, rates non-dimensionalised by
+   * JSBSim's bi2vel/ci2vel. Control derivatives are per-radian of surface deflection.
+   */
+  // Regular class (not case): Scala 2.10 caps case classes at 22 params.
+  final class AeroDerivatives(
+    val cl0: Double, val cla: Double, val clq: Double, val clde: Double,
+    val cd0: Double, val spanEfficiency: Double, val aspectRatio: Double, val cdde: Double,
+    val cm0: Double, val cma: Double, val cmq: Double, val cmde: Double,
+    val cyb: Double, val cyp: Double, val cyr: Double, val cydr: Double, val cyda: Double,
+    val clb: Double, val clp: Double, val clr: Double, val cldr: Double, val clda: Double,
+    val cnb: Double, val cnp: Double, val cnr: Double, val cndr: Double, val cnda: Double
+  )
+
+  /** Optional XFOIL-derived non-linear lift curve (alpha rad -> CL), overrides cl0+cla. */
+  final case class LiftTable(alphaRadToCl: Seq[(Double, Double)])
+
+  /** Optional electric propulsion (kept minimal; refined in the propulsion phase). */
+  final case class Propulsion(engineName: String, thrusterName: String)
+
+  final case class Aircraft(
+    name: String,
+    metrics: Metrics,
+    mass: MassBalance,
+    contacts: Seq[Contact],
+    controls: Seq[ControlSurface],
+    aero: AeroDerivatives,
+    liftTable: Option[LiftTable] = None,
+    propulsion: Option[Propulsion] = None
+  )
+
+  object ControlAxis extends Enumeration {
+    val Elevator, Aileron, Rudder = Value
+  }
+
+  // ---- Rendering ----
+
+  def write(ac: Aircraft): String = {
+    val sb = new StringBuilder
+    sb.append("""<?xml version="1.0"?>""").append("\n")
+    sb.append(s"""<fdm_config name="${xml(ac.name)}" version="2.0" release="ALPHA">""").append("\n")
+    sb.append(fileHeader(ac))
+    sb.append(metrics(ac.metrics))
+    sb.append(massBalance(ac.mass))
+    sb.append(groundReactions(ac.contacts))
+    sb.append(propulsion(ac.propulsion))
+    sb.append(flightControl(ac.controls))
+    sb.append(aerodynamics(ac))
+    sb.append("</fdm_config>\n")
+    sb.toString
+  }
+
+  private def f(v: Double): String = {
+    if (v == 0.0) "0" else new java.math.BigDecimal(v).round(new java.math.MathContext(8)).toPlainString
+  }
+
+  private def xml(s: String): String =
+    s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;")
+
+  private def fileHeader(ac: Aircraft): String =
+    s"""  <fileheader>
+    |    <author>AVL Editor</author>
+    |    <description>Auto-generated from AVL geometry + stability derivatives</description>
+    |  </fileheader>
+    |""".stripMargin
+
+  private def metrics(m: Metrics): String =
+    s"""  <metrics>
+    |    <wingarea unit="M2">${f(m.wingAreaM2)}</wingarea>
+    |    <wingspan unit="M">${f(m.wingSpanM)}</wingspan>
+    |    <chord unit="M">${f(m.chordM)}</chord>
+    |    <location name="AERORP" unit="M"><x>${f(m.aeroRp.x)}</x><y>${f(m.aeroRp.y)}</y><z>${f(m.aeroRp.z)}</z></location>
+    |  </metrics>
+    |""".stripMargin
+
+  private def massBalance(m: MassBalance): String =
+    s"""  <mass_balance>
+    |    <ixx unit="KG*M2">${f(m.ixx)}</ixx>
+    |    <iyy unit="KG*M2">${f(m.iyy)}</iyy>
+    |    <izz unit="KG*M2">${f(m.izz)}</izz>
+    |    <ixz unit="KG*M2">${f(m.ixz)}</ixz>
+    |    <emptywt unit="KG">${f(m.massKg)}</emptywt>
+    |    <location name="CG" unit="M"><x>${f(m.cg.x)}</x><y>${f(m.cg.y)}</y><z>${f(m.cg.z)}</z></location>
+    |  </mass_balance>
+    |""".stripMargin
+
+  private def groundReactions(contacts: Seq[Contact]): String = {
+    val body =
+      if (contacts.isEmpty) ""
+      else contacts.map { c =>
+        s"""    <contact type="BOGEY" name="${xml(c.name)}">
+      |      <location unit="M"><x>${f(c.at.x)}</x><y>${f(c.at.y)}</y><z>${f(c.at.z)}</z></location>
+      |      <static_friction>0.8</static_friction>
+      |      <dynamic_friction>0.5</dynamic_friction>
+      |      <rolling_friction>0.02</rolling_friction>
+      |      <spring_coeff unit="N/M">100.0</spring_coeff>
+      |      <damping_coeff unit="N/M/SEC">20.0</damping_coeff>
+      |    </contact>
+      |""".stripMargin
+      }.mkString
+    s"  <ground_reactions>\n$body  </ground_reactions>\n"
+  }
+
+  private def propulsion(p: Option[Propulsion]): String = p match {
+    case None => "  <propulsion/>\n"
+    case Some(pr) =>
+      s"""  <propulsion>
+      |    <engine file="${xml(pr.engineName)}">
+      |      <thruster file="${xml(pr.thrusterName)}"><location unit="M"><x>0</x><y>0</y><z>0</z></location></thruster>
+      |    </engine>
+      |  </propulsion>
+      |""".stripMargin
+  }
+
+  private def flightControl(controls: Seq[ControlSurface]): String = {
+    val channels = controls.map { c =>
+      val (cmd, pos) = c.axis match {
+        case ControlAxis.Elevator => ("fcs/elevator-cmd-norm", "fcs/elevator-pos-rad")
+        case ControlAxis.Aileron  => ("fcs/aileron-cmd-norm", "fcs/aileron-pos-rad")
+        case ControlAxis.Rudder   => ("fcs/rudder-cmd-norm", "fcs/rudder-pos-rad")
+      }
+      s"""    <channel name="${c.axis}">
+      |      <aerosurface_scale name="${pos}-scale">
+      |        <input>${cmd}</input>
+      |        <range><min>${f(-c.maxDeflectionRad)}</min><max>${f(c.maxDeflectionRad)}</max></range>
+      |        <output>${pos}</output>
+      |      </aerosurface_scale>
+      |    </channel>
+      |""".stripMargin
+    }.mkString
+    s"""  <flight_control name="FCS">
+    |$channels  </flight_control>
+    |""".stripMargin
+  }
+
+  // -- Aerodynamics: build force/moment axes from the linear derivatives --
+
+  private def term(name: String, factors: String): String =
+    s"""      <function name="aero/$name">
+    |        <product>
+    |$factors        </product>
+    |      </function>
+    |""".stripMargin
+
+  private def p(prop: String): String = s"          <property>$prop</property>\n"
+  private def v(value: Double): String = s"          <value>${f(value)}</value>\n"
+
+  private def aerodynamics(ac: Aircraft): String = {
+    val a = ac.aero
+    val qA = "aero/qbar-area"
+
+    // LIFT
+    val liftFns =
+      ac.liftTable match {
+        case Some(t) =>
+          val tbl = t.alphaRadToCl.map { case (al, cl) => s"            $al $cl" }.mkString("\n")
+          s"""      <function name="aero/force/lift_table">
+          |        <product>
+          |          <property>$qA</property>
+          |          <table><independentVar lookup="row">aero/alpha-rad</independentVar>
+          |            <tableData>
+          |$tbl
+          |            </tableData>
+          |          </table>
+          |        </product>
+          |      </function>
+          |""".stripMargin
+        case None =>
+          term("force/lift_0", p(qA) + v(a.cl0)) +
+          term("force/lift_alpha", p(qA) + v(a.cla) + p("aero/alpha-rad"))
+      }
+    val liftRates =
+      term("force/lift_q", p(qA) + v(a.clq) + p("aero/ci2vel") + p("velocities/q-aero-rad_sec")) +
+      term("force/lift_de", p(qA) + v(a.clde) + p("fcs/elevator-pos-rad"))
+
+    // DRAG: parasite + induced (CL^2 / (pi AR e)) + elevator
+    val k = 1.0 / (math.Pi * math.max(a.aspectRatio, 1e-6) * math.max(a.spanEfficiency, 1e-6))
+    val drag =
+      term("force/drag_0", p(qA) + v(a.cd0)) +
+      s"""      <function name="aero/force/drag_induced">
+      |        <product>
+      |          <property>$qA</property>
+      |          <value>${f(k)}</value>
+      |          <property>aero/cl-squared</property>
+      |        </product>
+      |      </function>
+      |""".stripMargin +
+      term("force/drag_de", p(qA) + v(a.cdde) + p("fcs/elevator-pos-rad"))
+
+    // SIDE
+    val side =
+      term("force/side_beta", p(qA) + v(a.cyb) + p("aero/beta-rad")) +
+      term("force/side_p", p(qA) + v(a.cyp) + p("aero/bi2vel") + p("velocities/p-aero-rad_sec")) +
+      term("force/side_r", p(qA) + v(a.cyr) + p("aero/bi2vel") + p("velocities/r-aero-rad_sec")) +
+      term("force/side_dr", p(qA) + v(a.cydr) + p("fcs/rudder-pos-rad")) +
+      term("force/side_da", p(qA) + v(a.cyda) + p("fcs/aileron-pos-rad"))
+
+    val span = "metrics/bw-ft"
+    val chord = "metrics/cbarw-ft"
+
+    // ROLL (about body x): qbar-area * span * Cl
+    val roll =
+      term("moment/roll_beta", p(qA) + p(span) + v(a.clb) + p("aero/beta-rad")) +
+      term("moment/roll_p", p(qA) + p(span) + v(a.clp) + p("aero/bi2vel") + p("velocities/p-aero-rad_sec")) +
+      term("moment/roll_r", p(qA) + p(span) + v(a.clr) + p("aero/bi2vel") + p("velocities/r-aero-rad_sec")) +
+      term("moment/roll_dr", p(qA) + p(span) + v(a.cldr) + p("fcs/rudder-pos-rad")) +
+      term("moment/roll_da", p(qA) + p(span) + v(a.clda) + p("fcs/aileron-pos-rad"))
+
+    // PITCH (about body y): qbar-area * chord * Cm
+    val pitch =
+      term("moment/pitch_0", p(qA) + p(chord) + v(a.cm0)) +
+      term("moment/pitch_alpha", p(qA) + p(chord) + v(a.cma) + p("aero/alpha-rad")) +
+      term("moment/pitch_q", p(qA) + p(chord) + v(a.cmq) + p("aero/ci2vel") + p("velocities/q-aero-rad_sec")) +
+      term("moment/pitch_de", p(qA) + p(chord) + v(a.cmde) + p("fcs/elevator-pos-rad"))
+
+    // YAW (about body z): qbar-area * span * Cn
+    val yaw =
+      term("moment/yaw_beta", p(qA) + p(span) + v(a.cnb) + p("aero/beta-rad")) +
+      term("moment/yaw_p", p(qA) + p(span) + v(a.cnp) + p("aero/bi2vel") + p("velocities/p-aero-rad_sec")) +
+      term("moment/yaw_r", p(qA) + p(span) + v(a.cnr) + p("aero/bi2vel") + p("velocities/r-aero-rad_sec")) +
+      term("moment/yaw_dr", p(qA) + p(span) + v(a.cndr) + p("fcs/rudder-pos-rad")) +
+      term("moment/yaw_da", p(qA) + p(span) + v(a.cnda) + p("fcs/aileron-pos-rad"))
+
+    s"""  <aerodynamics>
+    |    <axis name="LIFT">
+    |$liftFns$liftRates    </axis>
+    |    <axis name="DRAG">
+    |$drag    </axis>
+    |    <axis name="SIDE">
+    |$side    </axis>
+    |    <axis name="ROLL">
+    |$roll    </axis>
+    |    <axis name="PITCH">
+    |$pitch    </axis>
+    |    <axis name="YAW">
+    |$yaw    </axis>
+    |  </aerodynamics>
+    |""".stripMargin
+  }
+}

--- a/src/main/scala/com/abajar/avleditor/swt/MainWindow.scala
+++ b/src/main/scala/com/abajar/avleditor/swt/MainWindow.scala
@@ -31,7 +31,7 @@ import java.io.File;
 
 object MenuOption extends Enumeration {
   type MenuOption = Value
-  val Save, SaveAs, Open, ExportAsAvl, RunAvl, SetAvlExecutable, ClearAvlConfiguration = Value
+  val Save, SaveAs, Open, ExportAsAvl, ExportAsJsbsim, RunAvl, SetAvlExecutable, ClearAvlConfiguration = Value
 }
 
 import MenuOption._
@@ -166,6 +166,7 @@ class MainWindow(
           .addItem("Save as...", notifyMenuClick(MenuOption.SaveAs))
           .addItem("Open...", notifyMenuClick(MenuOption.Open))
           .addItem("Export As Avl", notifyMenuClick(MenuOption.ExportAsAvl))
+          .addItem("Export As JSBSim", notifyMenuClick(MenuOption.ExportAsJsbsim))
           .addItem("Run AVL", notifyMenuClick(MenuOption.RunAvl))
 
         menu.addSubmenu("Edit")

--- a/src/test/scala/com/abajar/avleditor/jsbsim/EndToEndCheck.scala
+++ b/src/test/scala/com/abajar/avleditor/jsbsim/EndToEndCheck.scala
@@ -1,0 +1,32 @@
+/*
+ * End-to-end: load a .avle, run AVL, export to JSBSim.
+ * Run: sbt "test:runMain com.abajar.avleditor.jsbsim.EndToEndCheck <file.avle> <outDir>"
+ */
+package com.abajar.avleditor.jsbsim
+
+import com.abajar.avleditor.crrcsim.CRRCSimRepository
+import com.abajar.avleditor.avl.connectivity.AvlRunner
+import com.abajar.avleditor.AvlManager
+import java.io.File
+import java.util.Properties
+import scala.collection.JavaConverters._
+
+object EndToEndCheck {
+  def main(args: Array[String]): Unit = {
+    val avle = args(0); val outDir = args(1)
+    val crrcsim = new CRRCSimRepository().restoreFromFile(new File(avle))
+    val avl = crrcsim.getAvl()
+    // Re-establish transient parent links (the editor does this after load).
+    avl.getGeometry().getSurfaces().asScala.foreach(_.initSectionParents())
+    avl.getGeometry().getBodies().asScala.foreach(_.initProfilePointParents())
+
+    val props = new Properties()
+    val ok = AvlManager.ensureAvlAvailable(props)
+    System.err.println(s"AVL available=$ok path=${props.getProperty("avl.path")}")
+
+    crrcsim.calculate()
+    val calc = new AvlRunner(props.getProperty("avl.path"), avl, crrcsim.getOriginPath()).getCalculation()
+    JsbsimExporter.export(new File(outDir), "eurofighter", crrcsim, calc)
+    System.err.println(s"EXPORT_DONE -> $outDir/aircraft/eurofighter/eurofighter.xml")
+  }
+}

--- a/src/test/scala/com/abajar/avleditor/jsbsim/JsbsimWriterCheck.scala
+++ b/src/test/scala/com/abajar/avleditor/jsbsim/JsbsimWriterCheck.scala
@@ -1,0 +1,39 @@
+/*
+ * Generates a sample JSBSim aircraft from representative small-aircraft stability
+ * derivatives and writes it to args(0), for validation against JSBSim standalone.
+ * Run: sbt "test:runMain com.abajar.avleditor.jsbsim.JsbsimWriterCheck /path/out.xml"
+ */
+package com.abajar.avleditor.jsbsim
+
+import JsbsimWriter._
+
+object JsbsimWriterCheck {
+  def sampleAircraft: Aircraft = Aircraft(
+    name = "gen",
+    metrics = Metrics(wingAreaM2 = 0.5, wingSpanM = 1.6, chordM = 0.33, aeroRp = Vec3(0.30, 0, 0.0)),
+    mass = MassBalance(massKg = 2.0, ixx = 0.06, iyy = 0.09, izz = 0.14, ixz = 0.0, cg = Vec3(0.30, 0, 0.0)),
+    contacts = Seq(Contact("MAIN", Vec3(0.32, 0, -0.10)), Contact("NOSE", Vec3(0.05, 0, -0.10))),
+    controls = Seq(
+      ControlSurface(ControlAxis.Elevator, math.toRadians(25)),
+      ControlSurface(ControlAxis.Aileron, math.toRadians(20)),
+      ControlSurface(ControlAxis.Rudder, math.toRadians(25))
+    ),
+    aero = new AeroDerivatives(
+      cl0 = 0.2, cla = 5.0, clq = 6.0, clde = 0.4,
+      cd0 = 0.025, spanEfficiency = 0.85, aspectRatio = 5.12, cdde = 0.0,
+      cm0 = 0.02, cma = -0.6, cmq = -8.0, cmde = -0.9,
+      cyb = -0.30, cyp = 0.0, cyr = 0.20, cydr = 0.15, cyda = 0.0,
+      clb = -0.05, clp = -0.45, clr = 0.10, cldr = 0.01, clda = 0.20,
+      cnb = 0.06, cnp = -0.03, cnr = -0.06, cndr = -0.07, cnda = -0.01
+    )
+  )
+
+  def main(args: Array[String]): Unit = {
+    val xml = write(sampleAircraft)
+    if (args.nonEmpty) {
+      val pw = new java.io.PrintWriter(args(0))
+      try pw.write(xml) finally pw.close()
+      System.err.println(s"Wrote ${args(0)} (${xml.length} chars)")
+    } else print(xml)
+  }
+}

--- a/src/test/scala/com/abajar/avleditor/jsbsim/JsbsimWriterCheck.scala
+++ b/src/test/scala/com/abajar/avleditor/jsbsim/JsbsimWriterCheck.scala
@@ -28,12 +28,34 @@ object JsbsimWriterCheck {
     )
   )
 
+  // CL(alpha) with a stall break, as XFOIL+critical-section would produce (3D).
+  def sampleLiftTable: LiftTable = LiftTable(Seq(
+    (math.toRadians(-5), -0.24), (math.toRadians(0), 0.20), (math.toRadians(5), 0.64),
+    (math.toRadians(10), 1.07), (math.toRadians(14), 1.25), (math.toRadians(16), 1.24),
+    (math.toRadians(18), 1.10)
+  ))
+
+  private def dump(path: String, content: String): Unit = {
+    val f = new java.io.File(path)
+    Option(f.getParentFile).foreach(_.mkdirs())
+    val pw = new java.io.PrintWriter(f)
+    try pw.write(content) finally pw.close()
+    System.err.println(s"Wrote $path (${content.length} chars)")
+  }
+
+  /** args: rootDir name [table]. Writes the full model (aero + optional lift table +
+   *  electric propulsion) plus its engine files into a JSBSim root directory. */
   def main(args: Array[String]): Unit = {
-    val xml = write(sampleAircraft)
-    if (args.nonEmpty) {
-      val pw = new java.io.PrintWriter(args(0))
-      try pw.write(xml) finally pw.close()
-      System.err.println(s"Wrote ${args(0)} (${xml.length} chars)")
-    } else print(xml)
+    if (args.length < 2) { print(write(sampleAircraft)); return }
+    val root = args(0); val name = args(1); val withTable = args.length > 2
+    val base = sampleAircraft.copy(
+      name = name,
+      propulsion = Some(Propulsion(motorKv = 960.0, batteryVolts = 14.63, coilResistanceOhm = 0.117,
+        noLoadCurrentA = 0.45, propDiameterM = 0.24, numBlades = 2, at = Vec3(0.0, 0, 0.0)))
+    )
+    val ac = if (withTable) base.copy(liftTable = Some(sampleLiftTable)) else base
+    val gm = generate(ac)
+    dump(s"$root/aircraft/$name/$name.xml", gm.aircraftXml)
+    gm.engineFiles.foreach { case (fn, content) => dump(s"$root/engine/$fn", content) }
   }
 }


### PR DESCRIPTION
Completes the CRRCsim→JSBSim pivot. JsbsimWriter generates metric JSBSim aircraft (aero from AVL derivatives, optional XFOIL lift table, electric BLDC propulsion); JsbsimExporter + 'Export As JSBSim' menu wire it into the app; YAML loader tolerates removed CRRCsim keys. Verified end-to-end: eurofighter .avle → AVL → JSBSim model that loads and flies in JSBSim standalone 1.3.1. 🤖 Generated with [Claude Code](https://claude.com/claude-code)