### PR TITLE
One-click Fly in FlightGear

### DIFF
--- a/src/main/scala/com/abajar/avleditor/AvlEditor.scala
+++ b/src/main/scala/com/abajar/avleditor/AvlEditor.scala
@@ -479,6 +479,7 @@ object AvlEditor{
       case ExportAsAvl => exportAsAVL
       case ExportAsJsbsim => exportAsJsbsim
       case ExportForFlightGear => exportForFlightGear
+      case FlyInFlightGear => flyInFlightGear
       case RunAvl => runAvl
       case SetAvlExecutable => setAvlExecutable
       case ClearAvlConfiguration => clearAvlConfiguration
@@ -758,9 +759,8 @@ object AvlEditor{
       })
     }
 
-    // Runs AVL for the current model, prompts for a directory, and hands (dir, name,
-    // calculation) to an exporter. Shared by the JSBSim and FlightGear exports.
-    private def exportWithAvl(dialogTitle: String)(writer: (File, String, com.abajar.avleditor.avl.runcase.AvlCalculation) => Unit): Unit = {
+    // Runs AVL for the current model and hands (name, calculation) to a callback.
+    private def withAvlCalculation(action: (String, com.abajar.avleditor.avl.runcase.AvlCalculation) => Unit): Unit = {
       if (!existsAvlExecutable) {
         logger.log(Level.WARNING, "AVL executable not configured; cannot compute derivatives for export")
         return
@@ -773,21 +773,26 @@ object AvlEditor{
         logger.log(Level.SEVERE, "Model validation failed; fix errors before exporting.")
         return
       }
-      val dirDialog = new org.eclipse.swt.widgets.DirectoryDialog(window.getShell)
-      dirDialog.setText(dialogTitle)
-      Option(dirDialog.open()).foreach { dir =>
-        try {
-          crrcsim.calculate()
-          val calc = new AvlRunner(configuration.getProperty("avl.path"), avl, crrcsim.getOriginPath()).getCalculation()
-          val name = currentFile.map(_.getName.replaceAll("\\.[^.]+$", "")).getOrElse("aircraft")
-          writer(new File(dir), name, calc)
-          logger.log(Level.INFO, s"Exported '$name' to $dir")
-        } catch {
-          case ex: Throwable =>
-            logger.log(Level.SEVERE, s"Export failed: ${ex.getMessage}", ex)
-        }
+      try {
+        crrcsim.calculate()
+        val calc = new AvlRunner(configuration.getProperty("avl.path"), avl, crrcsim.getOriginPath()).getCalculation()
+        val name = currentFile.map(_.getName.replaceAll("\\.[^.]+$", "")).getOrElse("aircraft")
+        action(name, calc)
+      } catch {
+        case ex: Throwable => logger.log(Level.SEVERE, s"Export failed: ${ex.getMessage}", ex)
       }
     }
+
+    // Runs AVL, prompts for a directory, and hands (dir, name, calculation) to an exporter.
+    private def exportWithAvl(dialogTitle: String)(writer: (File, String, com.abajar.avleditor.avl.runcase.AvlCalculation) => Unit): Unit =
+      withAvlCalculation { (name, calc) =>
+        val dirDialog = new org.eclipse.swt.widgets.DirectoryDialog(window.getShell)
+        dirDialog.setText(dialogTitle)
+        Option(dirDialog.open()).foreach { dir =>
+          writer(new File(dir), name, calc)
+          logger.log(Level.INFO, s"Exported '$name' to $dir")
+        }
+      }
 
     private def exportAsJsbsim: Unit =
       exportWithAvl("Choose JSBSim output directory") { (dir, name, calc) =>
@@ -798,6 +803,44 @@ object AvlEditor{
       exportWithAvl("Choose FlightGear aircraft directory") { (dir, name, calc) =>
         com.abajar.avleditor.jsbsim.FlightGearExporter.export(dir, name, crrcsim, calc)
       }
+
+    // One-click: export the FlightGear package to a fixed location and launch fgfs.
+    private def flyInFlightGear: Unit = withAvlCalculation { (name, calc) =>
+      val root = new File(AvlEditor.CONFIGURATION_ROOT, "flightgear")
+      com.abajar.avleditor.jsbsim.FlightGearExporter.export(root, name, crrcsim, calc)
+      resolveFlightGearExecutable() match {
+        case Some(exe) => launchFlightGear(exe, root, name)
+        case None => logger.log(Level.WARNING,
+          "FlightGear (fgfs) not found. Set it via 'Set FlightGear executable'.")
+      }
+    }
+
+    // Config first, then auto-search; if still missing, ask the user and persist it.
+    private def resolveFlightGearExecutable(): Option[String] =
+      FlightGearManager.findExecutable(configuration).orElse {
+        window.showOpenDialog(configuration.getProperty(FlightGearManager.CONFIG_KEY, "~/"),
+          "FlightGear executable", "*").map { file =>
+          FlightGearManager.setExecutable(configuration, file.getAbsolutePath())
+          file.getAbsolutePath()
+        }
+      }.map { path => persistConfiguration(); path }
+
+    private def launchFlightGear(exe: String, root: File, name: String): Unit = {
+      val log = new File(AvlEditor.CONFIGURATION_ROOT, "flightgear.log")
+      val pb = new ProcessBuilder(exe, s"--fg-aircraft=${root.getAbsolutePath}", s"--aircraft=$name")
+      pb.redirectErrorStream(true)
+      pb.redirectOutput(log)
+      pb.start()
+      logger.log(Level.INFO, s"Launching FlightGear with '$name' (log: ${log.getAbsolutePath})")
+    }
+
+    private def persistConfiguration(): Unit = {
+      try {
+        configuration.storeToXML(new FileOutputStream(CONFIGURATION_PATH), "Configuration file")
+      } catch {
+        case ex: Exception => logger.log(Level.FINE, "Unable to store configuration", ex)
+      }
+    }
 
     def runAvl: Unit = {
       if (!existsAvlExecutable) {

--- a/src/main/scala/com/abajar/avleditor/FlightGearManager.scala
+++ b/src/main/scala/com/abajar/avleditor/FlightGearManager.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2015  Hugo Freire Gil
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ */
+
+package com.abajar.avleditor
+
+import java.io.File
+import java.util.Properties
+import java.util.logging.{Level, Logger}
+
+/**
+ * Locates the FlightGear executable (`fgfs`) and remembers it in the configuration,
+ * mirroring how [[AvlManager]] handles AVL. Unlike AVL, FlightGear is a large
+ * end-user install and is NOT auto-downloaded: if it can't be found the caller
+ * should prompt the user to point at it (and the chosen path is then persisted).
+ */
+object FlightGearManager {
+
+  val logger = Logger.getLogger(FlightGearManager.getClass.getName)
+
+  /** Configuration key under which the resolved `fgfs` path is stored. */
+  val CONFIG_KEY = "flightgear.path"
+
+  private def isWindows = System.getProperty("os.name").toLowerCase.contains("win")
+  private def exeName = if (isWindows) "fgfs.exe" else "fgfs"
+
+  /**
+   * Return a usable `fgfs` path: the configured one if still valid, otherwise search
+   * PATH and the platform's common install locations. A newly discovered path is
+   * written back into `configuration` so it is remembered.
+   */
+  def findExecutable(configuration: Properties): Option[String] = {
+    val configured = Option(configuration.getProperty(CONFIG_KEY)).filter(isRunnable)
+    configured.orElse {
+      val discovered = searchOnPath.orElse(commonLocations.find(isRunnable))
+      discovered.foreach { p =>
+        configuration.setProperty(CONFIG_KEY, p)
+        logger.log(Level.INFO, s"FlightGear found at: $p")
+      }
+      if (discovered.isEmpty) logger.log(Level.INFO, "FlightGear (fgfs) not found automatically")
+      discovered
+    }
+  }
+
+  /** Persist a user-chosen path (from a file dialog). */
+  def setExecutable(configuration: Properties, path: String): Unit =
+    configuration.setProperty(CONFIG_KEY, path)
+
+  private def isRunnable(path: String): Boolean = {
+    val f = new File(path)
+    f.exists && f.canExecute
+  }
+
+  private def searchOnPath: Option[String] =
+    Option(System.getenv("PATH")).toSeq
+      .flatMap(_.split(File.pathSeparator))
+      .map(dir => new File(dir, exeName))
+      .find(f => f.exists && f.canExecute)
+      .map(_.getAbsolutePath)
+
+  private def commonLocations: Seq[String] = {
+    val os = System.getProperty("os.name").toLowerCase
+    if (os.contains("mac") || os.contains("darwin"))
+      Seq("/Applications/FlightGear.app/Contents/MacOS/fgfs")
+    else if (isWindows)
+      Seq(
+        "C:\\Program Files\\FlightGear\\bin\\fgfs.exe",
+        "C:\\Program Files\\FlightGear\\bin\\Win64\\fgfs.exe")
+    else
+      Seq("/usr/bin/fgfs", "/usr/games/fgfs", "/usr/local/bin/fgfs", "/snap/bin/fgfs")
+  }
+}

--- a/src/main/scala/com/abajar/avleditor/swt/MainWindow.scala
+++ b/src/main/scala/com/abajar/avleditor/swt/MainWindow.scala
@@ -31,7 +31,7 @@ import java.io.File;
 
 object MenuOption extends Enumeration {
   type MenuOption = Value
-  val Save, SaveAs, Open, ExportAsAvl, ExportAsJsbsim, ExportForFlightGear, RunAvl, SetAvlExecutable, ClearAvlConfiguration = Value
+  val Save, SaveAs, Open, ExportAsAvl, ExportAsJsbsim, ExportForFlightGear, FlyInFlightGear, RunAvl, SetAvlExecutable, ClearAvlConfiguration = Value
 }
 
 import MenuOption._
@@ -168,6 +168,7 @@ class MainWindow(
           .addItem("Export As Avl", notifyMenuClick(MenuOption.ExportAsAvl))
           .addItem("Export As JSBSim", notifyMenuClick(MenuOption.ExportAsJsbsim))
           .addItem("Export For FlightGear", notifyMenuClick(MenuOption.ExportForFlightGear))
+          .addItem("Fly in FlightGear", notifyMenuClick(MenuOption.FlyInFlightGear))
           .addItem("Run AVL", notifyMenuClick(MenuOption.RunAvl))
 
         menu.addSubmenu("Edit")

--- a/src/test/scala/com/abajar/avleditor/FlightGearManagerCheck.scala
+++ b/src/test/scala/com/abajar/avleditor/FlightGearManagerCheck.scala
@@ -1,0 +1,12 @@
+package com.abajar.avleditor
+object FlightGearManagerCheck {
+  def main(args: Array[String]): Unit = {
+    val p = new java.util.Properties()
+    val found = FlightGearManager.findExecutable(p)
+    val saved = p.getProperty(FlightGearManager.CONFIG_KEY)
+    println(s"found=$found saved=$saved")
+    val ok = found.isDefined && found.get == saved && saved.endsWith("fgfs")
+    println(if (ok) "FGMGR_OK" else "FGMGR_FAIL")
+    if (!ok) sys.exit(1)
+  }
+}


### PR DESCRIPTION
Adds FlightGearManager (locate fgfs like AvlManager, persist to config) and a 'Fly in FlightGear' action that exports the package and launches FlightGear. Manager verified (finds fgfs on PATH, stores in config). Actual FG launch not runnable headless here. 🤖 Generated with [Claude Code](https://claude.com/claude-code)